### PR TITLE
Refs #5 Add addButtonToControlBar option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,12 @@ After both Video.js and `silvermine-videojs-airplay` have loaded, follow the ste
 
 Once the plugin has been loaded and registered, add it to your Video.js player using
 Video.js' plugin configuration option (see the section under the heading "Setting up a
-Plugin" on [Video.js' plugin documentation page][videojs-docs].
+Plugin" on [Video.js' plugin documentation page][videojs-docs]. Use these options to
+configure the plugin:
+
+* **`plugins.airPlay.addButtonToControlBar`** - a `boolean` flag that tells the plugin
+  whether or not it should automatically add the AirPlay button to the Video.js
+  player's control bar component. Defaults to `true`.
 
 For example:
 
@@ -58,7 +63,9 @@ var options;
 options = {
    controls: true,
    plugins: {
-      airPlay: {}
+      airPlay: {
+         addButtonToControlBar: false, // defaults to `true`
+      }
    }
 };
 
@@ -118,7 +125,7 @@ image files:
   `"images/ic_airplay_white_24px.svg"`.
 * **`$icon-airplay--hover`** - the path to the icon image that is displayed when the user
   hovers over the AirPlay button. Defaults to `"images/ic_airplay_white_24px.svg"`.
-* **``$airplay-icon-size`** - the width and height of the icon (the button and icon is a
+* **`$airplay-icon-size`** - the width and height of the icon (the button and icon is a
   square). Defaults to `12px`.
 
 #### Images

--- a/src/js/enableAirPlay.js
+++ b/src/js/enableAirPlay.js
@@ -4,7 +4,8 @@
  * @module enableAirPlay
  */
 
-var hasAirPlayAPISupport = require('./lib/hasAirPlayAPISupport');
+var hasAirPlayAPISupport = require('./lib/hasAirPlayAPISupport'),
+    _ = require('underscore');
 
 /**
  * @private
@@ -25,7 +26,7 @@ function getExistingAirPlayButton(player) {
 function ensureAirPlayButtonExists(player, options) {
    var existingAirPlayButton = getExistingAirPlayButton(player);
 
-   if (!existingAirPlayButton) {
+   if (options.addButtonToControlBar && !existingAirPlayButton) {
       player.controlBar.addChild('airPlayButton', options);
    }
 }
@@ -92,9 +93,11 @@ function enableAirPlay(player, options) {
  */
 module.exports = function(videojs) {
    videojs.registerPlugin('airPlay', function(options) {
+      var pluginOptions = _.extend({ addButtonToControlBar: true }, options || {});
+
       // `this` is an instance of a Video.js Player.
       // Wait until the player is "ready" so that the player's control bar component has
       // been created.
-      this.ready(enableAirPlay.bind(this, this, options || {}));
+      this.ready(enableAirPlay.bind(this, this, pluginOptions));
    });
 };


### PR DESCRIPTION
Adds the option to allow plugin users to disable automatically inserting
the AirPlayButton component into the player's ControlBar component.