### PR TITLE
Added an option to start playing when airplay target has changed. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ configure the plugin:
   whether or not it should automatically add the AirPlay button to the Video.js
   player's control bar component. Defaults to `true`.
 
+* **`plugins.airPlay.autoPlayOnTargetChange`** - a `boolean` flag that tells the plugin
+  whether or not it should automatically start playing after airplay target has changed.
+
+
 For example:
 
 ```js
@@ -70,6 +74,7 @@ options = {
    plugins: {
       airPlay: {
          addButtonToControlBar: false, // defaults to `true`
+         autoPlayOnTargetChange: true, //defaults to `false`
       }
    }
 };

--- a/src/js/components/AirPlayButton.js
+++ b/src/js/components/AirPlayButton.js
@@ -97,9 +97,11 @@ AirPlayButton = {
          }
       });
 
-      mediaEl.addEventListener('webkitcurrentplaybacktargetiswirelesschanged', function(e) {
-         self.player().play();
-      });
+      if (self.options().autoPlayOnTargetChange) {
+         mediaEl.addEventListener('webkitcurrentplaybacktargetiswirelesschanged', function(e) {
+            self.player().play();
+         });
+      }
    },
 };
 

--- a/src/js/components/AirPlayButton.js
+++ b/src/js/components/AirPlayButton.js
@@ -96,6 +96,10 @@ AirPlayButton = {
             self.hide();
          }
       });
+
+      mediaEl.addEventListener('webkitcurrentplaybacktargetiswirelesschanged', function(e) {
+         self.player().play();
+      });
    },
 };
 

--- a/src/js/enableAirPlay.js
+++ b/src/js/enableAirPlay.js
@@ -93,7 +93,7 @@ function enableAirPlay(player, options) {
  */
 module.exports = function(videojs) {
    videojs.registerPlugin('airPlay', function(options) {
-      var pluginOptions = _.extend({ addButtonToControlBar: true }, options || {});
+      var pluginOptions = _.extend({ addButtonToControlBar: true, autoPlayOnTargetChange: false }, options || {});
 
       // `this` is an instance of a Video.js Player.
       // Wait until the player is "ready" so that the player's control bar component has


### PR DESCRIPTION
With this option player will automatically start playing when the user has selected a new airplay device. 