### PR TITLE
docs: Remove data-setup property from demo

### DIFF
--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -11,12 +11,18 @@
 <body>
    <h1>Demo of <code>silvermine-videojs-airplay</code></h1>
 
-   <video id="video_1" class="video-js vjs-default-skin" controls preload="auto" data-setup='{ "fluid": "true" }'>
+   <video id="video_1" class="video-js vjs-default-skin" controls preload="auto">
       <source src="http://www.caminandes.com/download/03_caminandes_llamigos_1080p.mp4" type="video/mp4">
    </video>
 
    <script>
-      videojs("video_1", {}, function() {
+      var options;
+
+      options = {
+         fluid: true,
+      };
+
+      videojs('video_1', options, function() {
          var player = this;
 
          player.airPlay();


### PR DESCRIPTION
Using the `data-setup` attribute in the video component will automatically initialize the player with the options provided. 

However, if the player is also initialized in our code using the `videojs('my-player')` function, it can sometimes cause unwanted side effects.