### PR TITLE
feat: Add optional "AirPlay" label to button component

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ configure the plugin:
      the last child of the control bar. A value less than 0 puts the button at the specified
      position from the end of the control bar. Note that it's likely not all child components
      of the control bar are visible.
+   * **`plugins.airPlay.addAirPlayLabelToButton`** (default: `false`) - by default, the AirPlay
+     button component will display only an icon. Setting `addAirPlayLabelToButton` to `true`
+     will display a label titled `"AirPlay"` alongside the default icon.
 
 For example:
 
@@ -95,12 +98,15 @@ player.airPlay(); // initializes the AirPlay plugin
 
 #### Localization
 
-The `AirPlayButton` component has one translated string: "Start AirPlay". The "Start
-AirPlay" string appears in both of the standard places for Button component accessibility
-text: inside the `.vjs-control-text` span and as the `<button>` element's `title` attribute.
+The `AirPlayButton` component has two translated strings: "Start AirPlay" and "AirPlay".
+
+   * The "Start AirPlay" string appears in both of the standard places for Button component
+     text: inside the `.vjs-control-text` span and as the `<button>` element's `title` attribute.
+   * The "AirPlay" string appears in an optional label within the Button component: inside
+     the `.vjs-airplay-button-label` span.
 
 To localize the AirPlay button text, follow the steps in the [Video.js Languages tutorial][videojs-docs]
-to add a `"Start AirPlay"` key to the map of translation strings.
+to add `"Start AirPlay"` and `"AirPlay"` keys to the map of translation strings.
 
 ### Using the npm module
 

--- a/src/js/components/AirPlayButton.js
+++ b/src/js/components/AirPlayButton.js
@@ -27,15 +27,26 @@ AirPlayButton = {
     * @constructs
     * @extends external:Button
     */
-   constructor: function() {
+   constructor: function(player, options) {
       this.constructor.super_.apply(this, arguments);
 
       if (!hasAirPlayAPISupport()) {
          this.hide();
       }
 
-      this.controlText('Start AirPlay');
       this._reactToAirPlayAvailableEvents();
+
+      if (options.addAirPlayLabelToButton) {
+         this.el().classList.add('vjs-airplay-button-lg');
+
+         this._labelEl = document.createElement('span');
+         this._labelEl.classList.add('vjs-airplay-button-label');
+         this._labelEl.textContent = this.localize('AirPlay');
+
+         this.el().appendChild(this._labelEl);
+      } else {
+         this.controlText('Start AirPlay');
+      }
    },
 
    /**

--- a/src/scss/videojs-airplay.scss
+++ b/src/scss/videojs-airplay.scss
@@ -4,6 +4,7 @@ $icon-airplay--hover: 'images/ic_airplay_white_24px.svg' !default;
 
 // Sizes
 $airplay-icon-size: 12px !default;
+$airplay-button-spacing: 4px !default;
 
 .vjs-airplay-button {
    .vjs-icon-placeholder {
@@ -18,5 +19,20 @@ $airplay-icon-size: 12px !default;
       .vjs-icon-placeholder {
          background-image: url($icon-airplay--hover);
       }
+   }
+}
+
+.vjs-airplay-button.vjs-airplay-button-lg:not(.vjs-hidden) {
+   // Fits both the icon and the label on the same control
+   display: flex;
+   align-items: center;
+   width: auto;
+   padding: 0 $airplay-button-spacing;
+   .vjs-airplay-button-label {
+      flex-grow: 1;
+      margin-left: $airplay-button-spacing;
+   }
+   .vjs-icon-placeholder {
+      flex-grow: 1;
    }
 }


### PR DESCRIPTION
Adds `plugins.airPlay.addAirPlayLabelToButton` as an option in the plugin configuration options.

By default, the AirPlay button component will display only an icon. Setting `addAirPlayLabelToButton` to `true` will display a label titled "AirPlay" alongside the default icon.

```js
    options = {
       fluid: true,
       plugins: {
          airPlay: {
             addButtonToControlBar: true, // defaults to `true`
             addAirPlayLabelToButton: true, // defaults to `false`
          }
       }
    };
```

If the configuration `addButtonToControlBar` is set to `false`, you will have to pass in the plugin options into the `airPlay()` method on ready.

```js
    videojs('video_1', options, function() {
         var player = this;

         player.airPlay(options.plugins.airPlay);
    });

```
Style the airPlay button label by editing .`vjs-airplay-button-label`.