### PR TITLE
build: Disable merge_vars in Gruntfile uglify process

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -106,7 +106,10 @@ module.exports = function(grunt) {
                sourceMap: DEBUG,
                sourceMapIncludeSources: DEBUG,
                mangle: !DEBUG,
-               compress: !DEBUG,
+               // Disable the `merge_vars` option in the compression phase.
+               // `merge_vars` aggressively reuses variable names, which can lead to
+               // unexpected behavior or runtime errors in certain cases.
+               compress: DEBUG ? false : { merge_vars: false }, // eslint-disable-line camelcase
                beautify: DEBUG,
             },
          },


### PR DESCRIPTION
`merge_vars` aggressively reuses variable names, which can lead to unexpected behavior or runtime errors in certain cases. It was introduced grunt-contrib-uglify 5.0.1 and it is now turned on by default. 
We are turning it off to ensure it does not break this project.